### PR TITLE
feat(grass block): skip dirt event when seeds are used on farmland (fixes #837) (fixes #1174)

### DIFF
--- a/sources-fabric/Grass Seeds (Fabric)/src/main/java/com/natamus/grassseeds/events/GrassEvent.java
+++ b/sources-fabric/Grass Seeds (Fabric)/src/main/java/com/natamus/grassseeds/events/GrassEvent.java
@@ -37,15 +37,21 @@ public class GrassEvent {
 		
 		BlockPos cpos = BlockPosFunctions.getBlockPosFromHitResult(hitResult).below();
 		Block block = world.getBlockState(cpos).getBlock();
+		BlockPos up = cpos.above();
+		Block upBlock = world.getBlockState(up).getBlock();
+
+		if (upBlock.equals(Blocks.FARMLAND)) {
+			return InteractionResult.PASS;
+		}
+
 		if (block.equals(Blocks.DIRT)) {
 			world.setBlockAndUpdate(cpos, Blocks.GRASS_BLOCK.defaultBlockState());
 		}
 		else if (block.equals(Blocks.GRASS_BLOCK)) {
-			BlockPos up = cpos.above();
-			if (world.getBlockState(up).getBlock().equals(Blocks.AIR)) {
+			if (upBlock.equals(Blocks.AIR)) {
 				world.setBlockAndUpdate(up, Blocks.GRASS.defaultBlockState());
 			}
-			else if (world.getBlockState(up).getBlock().equals(Blocks.GRASS)) {
+			else if (upBlock.equals(Blocks.GRASS)) {
 				upgradeGrass(world, up);
 			}
 			else {


### PR DESCRIPTION
I'm not sure what the process is for building and testing in a multi-mod/multi-loader project, so let me know if there's something more I can/should do for this. I also am not sure what would be needed to backport the fix to previous versions, if possible.

I hope this helps, and thanks for the many amazing mods you have published!

fixes #837 
fixes #1174