### PR TITLE
Sharpened uses now retains formatting

### DIFF
--- a/sources-fabric/Grindstone Sharper Tools (Fabric)/src/main/java/com/natamus/grindstonesharpertools/Main.java
+++ b/sources-fabric/Grindstone Sharper Tools (Fabric)/src/main/java/com/natamus/grindstonesharpertools/Main.java
@@ -31,12 +31,8 @@ public class Main implements ModInitializer {
 	}
 	
 	private void registerEvents() {
-		CollectiveEntityEvents.ON_LIVING_DAMAGE_CALC.register((Level world, Entity entity, DamageSource damageSource, float damageAmount) -> {
-			return GrindEvent.onDamage(world, entity, damageSource, damageAmount);
-		});
-		
-		UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
-			return GrindEvent.onClick(player, world, hand, hitResult);
-		});
+		CollectiveEntityEvents.ON_LIVING_DAMAGE_CALC.register(GrindEvent::onDamage);
+
+		UseBlockCallback.EVENT.register(GrindEvent::onClick);
 	}
 }

--- a/sources-fabric/Grindstone Sharper Tools (Fabric)/src/main/java/com/natamus/grindstonesharpertools/config/ConfigHandler.java
+++ b/sources-fabric/Grindstone Sharper Tools (Fabric)/src/main/java/com/natamus/grindstonesharpertools/config/ConfigHandler.java
@@ -34,6 +34,7 @@ public class ConfigHandler {
 	public static PropertyMirror<Boolean> showUsesLeftInItemName = PropertyMirror.create(ConfigTypes.BOOLEAN);
 	public static PropertyMirror<String> nameUsesPrefix = PropertyMirror.create(ConfigTypes.STRING);
 	public static PropertyMirror<String> nameUsesSuffix = PropertyMirror.create(ConfigTypes.STRING);
+	public static PropertyMirror<Boolean> infiniteCreativeUses = PropertyMirror.create(ConfigTypes.BOOLEAN);
 
 	private static final ConfigTree CONFIG = ConfigTree.builder() 
 			.beginValue("usesAfterGrinding", ConfigTypes.INTEGER, 32)
@@ -59,6 +60,10 @@ public class ConfigHandler {
 			.beginValue("nameUsesSuffix", ConfigTypes.STRING, ")")
 			.withComment("The suffix of the sharpened uses left in the tool name.")
 			.finishValue(nameUsesSuffix::mirror)
+
+			.beginValue("infiniteCreativeUses", ConfigTypes.BOOLEAN, false)
+			.withComment("Whether to decrease sharpened uses in creative.")
+			.finishValue(infiniteCreativeUses::mirror)
 
 			.build();
 

--- a/sources-fabric/Grindstone Sharper Tools (Fabric)/src/main/java/com/natamus/grindstonesharpertools/events/GrindEvent.java
+++ b/sources-fabric/Grindstone Sharper Tools (Fabric)/src/main/java/com/natamus/grindstonesharpertools/events/GrindEvent.java
@@ -13,7 +13,6 @@ import com.natamus.collective_fabric.functions.ItemFunctions;
 import com.natamus.collective_fabric.functions.StringFunctions;
 import com.natamus.grindstonesharpertools.config.ConfigHandler;
 import com.natamus.grindstonesharpertools.util.Util;
-
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
@@ -29,82 +28,81 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.phys.HitResult;
 
 public class GrindEvent {
-	public static float onDamage(Level world, Entity entity, DamageSource damageSource, float damageAmount) {
-		Entity source = damageSource.getEntity();
-		if (source == null) {
-			return damageAmount;
-		}
-		
-		if (world.isClientSide) {
-			return damageAmount;
-		}
-		
-		if (source instanceof Player == false) {
-			return damageAmount;
-		}
-		
-		Player player = (Player)source;
-		ItemStack hand = player.getMainHandItem();
-		
-		if (ItemFunctions.isTool(hand)) {
-			CompoundTag nbtc = hand.getOrCreateTag();
-			if (nbtc.contains("sharper")) {
-				int sharpleft = nbtc.getInt("sharper")-1;
-				
-				if (sharpleft > 0) {
-					nbtc.putInt("sharper", sharpleft);
-					double modifier = ConfigHandler.sharpenedDamageModifier.getValue();
-					damageAmount *= (float)modifier;
-					
-					int totaluses = ConfigHandler.usesAfterGrinding.getValue();
-					if ((double)sharpleft == (double)totaluses*0.75) {
-						StringFunctions.sendMessage(player, "Your sharpened tool has 75% of its uses left.", ChatFormatting.BLUE);
-					}
-					else if ((double)sharpleft == (double)totaluses*0.5) {
-						StringFunctions.sendMessage(player, "Your sharpened tool has 50% of its uses left.", ChatFormatting.BLUE);
-					}
-					else if ((double)sharpleft == (double)totaluses*0.25) {
-						StringFunctions.sendMessage(player, "Your sharpened tool has 25% of its uses left.", ChatFormatting.BLUE);
-					}
-					else if ((double)sharpleft == (double)totaluses*0.1) {
-						StringFunctions.sendMessage(player, "Your sharpened tool has 10% of its uses left.", ChatFormatting.BLUE);
-					}
-				}
-				else {
-					nbtc.remove("sharper");
-					StringFunctions.sendMessage(player, "Your tool is no longer sharpened.", ChatFormatting.RED);
-				}
-				hand.setTag(nbtc);
-				Util.updateName(hand, sharpleft);
-			}
-		}
-		
-		return damageAmount;
-	}
-	
-	public static InteractionResult onClick(Player player, Level world, InteractionHand hand, HitResult hitResult) {
-		if (world.isClientSide || !hand.equals(InteractionHand.MAIN_HAND)) {
-			return InteractionResult.PASS;
-		}
-		
-		BlockPos pos = BlockPosFunctions.getBlockPosFromHitResult(hitResult);
-		Block block = world.getBlockState(pos).getBlock();
-		if (block.equals(Blocks.GRINDSTONE)) {
-			if (player.isCrouching()) {
-				ItemStack itemstack = player.getItemInHand(hand);
-				if (ItemFunctions.isTool(itemstack)) {
-					CompoundTag nbtc = itemstack.getOrCreateTag();
-					int sharpeneduses = ConfigHandler.usesAfterGrinding.getValue();
-					
-					nbtc.putInt("sharper", sharpeneduses);
-					itemstack.setTag(nbtc);
-					Util.updateName(itemstack, sharpeneduses);
-					StringFunctions.sendMessage(player, "Your tool has been sharpened with " + sharpeneduses + " uses.", ChatFormatting.DARK_GREEN);
-					return InteractionResult.FAIL;
-				}
-			}
-		}
-		
-		return InteractionResult.PASS;
-	}
+    public static float onDamage(Level world, Entity entity, DamageSource damageSource, float damageAmount) {
+        Entity source = damageSource.getEntity();
+        if (source == null) {
+            return damageAmount;
+        }
+
+        if (world.isClientSide) {
+            return damageAmount;
+        }
+
+        if (!(source instanceof Player)) {
+            return damageAmount;
+        }
+
+        Player player = (Player) source;
+        ItemStack hand = player.getMainHandItem();
+
+        if (ItemFunctions.isTool(hand)) {
+            CompoundTag nbtc = hand.getOrCreateTag();
+            if (nbtc.contains("sharper")) {
+                int sharpLeft = nbtc.getInt("sharper");
+                if (!player.isCreative() || !ConfigHandler.infiniteCreativeUses.getValue()) {
+                    sharpLeft--;
+                }
+
+                if (sharpLeft > 0) {
+                    nbtc.putInt("sharper", sharpLeft);
+                    double modifier = ConfigHandler.sharpenedDamageModifier.getValue();
+                    damageAmount *= (float) modifier;
+
+                    int totalUses = ConfigHandler.usesAfterGrinding.getValue();
+                    if ((double) sharpLeft == (double) totalUses * 0.75) {
+                        StringFunctions.sendMessage(player, "Your sharpened tool has 75% of its uses left.", ChatFormatting.BLUE);
+                    } else if ((double) sharpLeft == (double) totalUses * 0.5) {
+                        StringFunctions.sendMessage(player, "Your sharpened tool has 50% of its uses left.", ChatFormatting.BLUE);
+                    } else if ((double) sharpLeft == (double) totalUses * 0.25) {
+                        StringFunctions.sendMessage(player, "Your sharpened tool has 25% of its uses left.", ChatFormatting.BLUE);
+                    } else if ((double) sharpLeft == (double) totalUses * 0.1) {
+                        StringFunctions.sendMessage(player, "Your sharpened tool has 10% of its uses left.", ChatFormatting.BLUE);
+                    }
+                } else {
+                    nbtc.remove("sharper");
+                    StringFunctions.sendMessage(player, "Your tool is no longer sharpened.", ChatFormatting.RED);
+                }
+                hand.setTag(nbtc);
+                Util.updateName(hand, sharpLeft);
+            }
+        }
+
+        return damageAmount;
+    }
+
+    public static InteractionResult onClick(Player player, Level world, InteractionHand hand, HitResult hitResult) {
+        if (world.isClientSide || !hand.equals(InteractionHand.MAIN_HAND)) {
+            return InteractionResult.PASS;
+        }
+
+        BlockPos pos = BlockPosFunctions.getBlockPosFromHitResult(hitResult);
+        Block block = world.getBlockState(pos).getBlock();
+        if (block.equals(Blocks.GRINDSTONE)) {
+            if (player.isCrouching()) {
+                ItemStack itemstack = player.getItemInHand(hand);
+                if (ItemFunctions.isTool(itemstack)) {
+                    CompoundTag nbtc = itemstack.getOrCreateTag();
+                    int sharpeneduses = ConfigHandler.usesAfterGrinding.getValue();
+
+                    nbtc.putInt("sharper", sharpeneduses);
+                    itemstack.setTag(nbtc);
+                    Util.updateName(itemstack, sharpeneduses);
+                    StringFunctions.sendMessage(player, "Your tool has been sharpened with " + sharpeneduses + " uses.", ChatFormatting.DARK_GREEN);
+                    return InteractionResult.FAIL;
+                }
+            }
+        }
+
+        return InteractionResult.PASS;
+    }
 }

--- a/sources-fabric/Grindstone Sharper Tools (Fabric)/src/main/java/com/natamus/grindstonesharpertools/util/Util.java
+++ b/sources-fabric/Grindstone Sharper Tools (Fabric)/src/main/java/com/natamus/grindstonesharpertools/util/Util.java
@@ -8,26 +8,38 @@
 
 package com.natamus.grindstonesharpertools.util;
 
-import com.natamus.collective_fabric.functions.StringFunctions;
 import com.natamus.grindstonesharpertools.config.ConfigHandler;
-
-import net.minecraft.world.item.ItemStack;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.ComponentContents;
+import net.minecraft.network.chat.MutableComponent;
+import net.minecraft.network.chat.Style;
+import net.minecraft.world.item.ItemStack;
+
+import java.util.List;
 
 public class Util {
-	public static void updateName(ItemStack itemstack, int uses) {
-		if (!ConfigHandler.showUsesLeftInItemName.getValue()) {
-			return;
-		}
-		
-		String prefix = ConfigHandler.nameUsesPrefix.getValue();
-		String name = itemstack.getHoverName().getString();
-		if (name.contains(prefix)) {
-			name = name.split(StringFunctions.escapeSpecialRegexChars(" " + prefix))[0];
-		}
-		if (uses > 0) {
-			name = name + " " + ConfigHandler.nameUsesPrefix.getValue() + uses + ConfigHandler.nameUsesSuffix.getValue();
-		}
-		itemstack.setHoverName(Component.literal(name));
-	}
+    public static void updateName(ItemStack itemstack, int uses) {
+        if (!ConfigHandler.showUsesLeftInItemName.getValue()) {
+            return;
+        }
+
+        String prefix = ConfigHandler.nameUsesPrefix.getValue();
+        Component hoverName = itemstack.getHoverName();
+        String name = hoverName.getString();
+        List<Component> flatList = hoverName.toFlatList();
+
+        flatList.removeIf(component -> component.toString().contains(prefix));
+        if (uses > 0) {
+            Style last = flatList.get(flatList.size() - 1).getStyle();
+            flatList.add(
+                    Component.literal(" " + ConfigHandler.nameUsesPrefix.getValue()
+                            + uses + ConfigHandler.nameUsesSuffix.getValue()).withStyle(last)
+            );
+        }
+        MutableComponent mutableComponent = MutableComponent.create(ComponentContents.EMPTY);
+        for (Component component : flatList) {
+            mutableComponent.append(component);
+        }
+        itemstack.setHoverName(mutableComponent);
+    }
 }


### PR DESCRIPTION
I noticed that custom items given to me with a datapack with custom formatting would revert to the "default" format when sharpened, so now it takes the formatting of the last part of the item name instead. 
I also noticed that creative users lose sharp uses when it probably makes sense if they shoudn't, so i added a config option for that which defaults to false.
Demonstrating the color working properly:
![colordemo](https://user-images.githubusercontent.com/57734230/183232693-4491adbb-eeea-409f-9222-f177a8d51fd5.gif)
Demonstrating that it loses the suffix properly (sorry my screen recorder is really laggy and loses many frames; and i had to compress on top of that to upload 2 github):
![disappear](https://user-images.githubusercontent.com/57734230/183232735-6cfd0ba5-2a29-45a9-9b95-ff095e2c2869.gif)
Demonstrating creative property:
![creative](https://user-images.githubusercontent.com/57734230/183232745-9f9078bf-efab-443e-a467-fdfe6657b3ef.gif)

