### PR TITLE
[Fabric, Tree Harvester] Scan registry for Axes in server started event to catch items from all mods

### DIFF
--- a/sources-fabric/Tree Harvester (Fabric)/src/main/java/com/natamus/treeharvester/Main.java
+++ b/sources-fabric/Tree Harvester (Fabric)/src/main/java/com/natamus/treeharvester/Main.java
@@ -17,6 +17,7 @@ import com.natamus.treeharvester.events.TreeEvent;
 import com.natamus.treeharvester.util.Reference;
 import com.natamus.treeharvester.util.Util;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
@@ -27,6 +28,8 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 
 public class Main implements ModInitializer {
+	private boolean blackListSetup;
+
 	@Override
 	public void onInitialize() {
 		ConfigHandler.setup();
@@ -37,12 +40,18 @@ public class Main implements ModInitializer {
 	}
 	
 	private void registerEvents() {
-		try {
-			Util.setupAxeBlacklist();
-		}
-		catch(Exception ex) {
-			return;
-		}
+		ServerLifecycleEvents.SERVER_STARTING.register(server -> {
+			if (blackListSetup) {
+				return;
+			}
+			blackListSetup = true;
+			try {
+				Util.setupAxeBlacklist();
+			}
+			catch(Exception ex) {
+				return;
+			}
+		});
 
 		ServerWorldEvents.LOAD.register((MinecraftServer server, ServerLevel world) -> {
 			TreeEvent.onWorldLoad(world);


### PR DESCRIPTION
I was having trouble with tree harvester on Fabric since it wouldn't allow me to harvest with AE2 axes.
Turns out that the mod init of tree harvester just ran before AE2 so it wouldn't see the axe in the registry yet.
Moving the registry scanning to the server started event (and just doing it once) fixes the issue for me.

This might also fix other reported issues for the fabric version of tree harvester.