### PR TITLE
Fire an event on the forge bus whenever a player summons a pumpkillager

### DIFF
--- a/sources/Pumpkillager's Quest/src/main/java/com/natamus/pumpkillagersquest/api/PumpkillagerSummonEvent.java
+++ b/sources/Pumpkillager's Quest/src/main/java/com/natamus/pumpkillagersquest/api/PumpkillagerSummonEvent.java
@@ -1,0 +1,59 @@
+package com.natamus.pumpkillagersquest.api;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.npc.Villager;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.eventbus.api.Event;
+
+/**
+ * This event is fired on the {@link net.minecraftforge.common.MinecraftForge#EVENT_BUS} whenever a player summons the
+ * pumpkillager. The event is not cancelable and does not have a result.
+ */
+public class PumpkillagerSummonEvent extends Event {
+
+    private final Player summoner;
+    private final Villager pumpkillager;
+    private final BlockPos pos;
+    private final Type type;
+    
+    public PumpkillagerSummonEvent(Player summoner, Villager pumpkillager, BlockPos pos, Type type) {
+        this.summoner = summoner;
+        this.pumpkillager = pumpkillager;
+        this.pos = pos.immutable();
+        this.type = type;
+    }
+
+    /**
+     * Gets the player, who summoned the pumpkillager.
+     */
+    public Player getSummoner() {
+        return summoner;
+    }
+
+    /**
+     * Gets the pumpkillager entity.
+     */
+    public Villager getPumpkillager() {
+        return pumpkillager;
+    }
+
+    /**
+     * Gets the center block pos of the summoning ritual.
+     */
+    public BlockPos getPos() {
+        return pos;
+    }
+
+    /**
+     * Gets the type of pumpkillager that is summoned.
+     */
+    public Type getType() {
+        return type;
+    }
+
+    public enum Type {
+        INITIAL_SUMMON,
+        POST_RITUAL,
+        FINAL_BOSS
+    }
+}

--- a/sources/Pumpkillager's Quest/src/main/java/com/natamus/pumpkillagersquest/pumpkillager/Actions.java
+++ b/sources/Pumpkillager's Quest/src/main/java/com/natamus/pumpkillagersquest/pumpkillager/Actions.java
@@ -17,6 +17,7 @@
 package com.natamus.pumpkillagersquest.pumpkillager;
 
 import com.mojang.datafixers.util.Pair;
+import com.natamus.pumpkillagersquest.api.PumpkillagerSummonEvent;
 import com.natamus.pumpkillagersquest.config.ConfigHandler;
 import com.natamus.pumpkillagersquest.util.*;
 import net.minecraft.ChatFormatting;
@@ -50,6 +51,7 @@ import net.minecraft.world.level.block.SkullBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.MinecraftForge;
 
 import java.util.List;
 import java.util.Set;
@@ -159,6 +161,8 @@ public class Actions {
 
         level.setBlock(centerPos.below(), Blocks.OBSIDIAN.defaultBlockState(), 3);
         level.addFreshEntity(pumpkillager);
+
+        MinecraftForge.EVENT_BUS.post(new PumpkillagerSummonEvent(player, pumpkillager, centerPos, PumpkillagerSummonEvent.Type.FINAL_BOSS));
 
         Conversations.startTalking(level, pumpkillager, player, 7);
     }

--- a/sources/Pumpkillager's Quest/src/main/java/com/natamus/pumpkillagersquest/pumpkillager/Manage.java
+++ b/sources/Pumpkillager's Quest/src/main/java/com/natamus/pumpkillagersquest/pumpkillager/Manage.java
@@ -18,6 +18,7 @@ package com.natamus.pumpkillagersquest.pumpkillager;
 
 import com.mojang.datafixers.util.Pair;
 import com.natamus.collective.functions.EntityFunctions;
+import com.natamus.pumpkillagersquest.api.PumpkillagerSummonEvent;
 import com.natamus.pumpkillagersquest.util.Data;
 import com.natamus.pumpkillagersquest.util.Reference;
 import com.natamus.pumpkillagersquest.util.SpookyHeads;
@@ -45,6 +46,7 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.MinecraftForge;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -72,6 +74,9 @@ public class Manage {
         pumpkillager.lookAt(EntityAnchorArgument.Anchor.EYES, player.position());
 
         placePumpkillagerBlocks(level, pos, placementId);
+
+        MinecraftForge.EVENT_BUS.post(new PumpkillagerSummonEvent(player, pumpkillager, pos, conversationId == 0 ? PumpkillagerSummonEvent.Type.INITIAL_SUMMON : PumpkillagerSummonEvent.Type.POST_RITUAL));
+        
         Conversations.startTalking(level, pumpkillager, player, conversationId);
     }
 


### PR DESCRIPTION
This allows other mods to easily listen to that event and trigger custom behaviour.

My use case for this: Just like the past two years, I want to make a spooky version of the [Bongo](https://www.curseforge.com/minecraft/mc-mods/bongo) mod with tasks for all the (forge) SpookyJam submissions. The event would allow me to add a task that is completed whenever a player summons a pumpkillager.
