### PR TITLE
Replace flowers task is now always scheduled

### DIFF
--- a/sources/Random Bone Meal Flowers/src/main/java/com/natamus/randombonemealflowers/events/FlowerEvent.java
+++ b/sources/Random Bone Meal Flowers/src/main/java/com/natamus/randombonemealflowers/events/FlowerEvent.java
@@ -18,9 +18,11 @@ package com.natamus.randombonemealflowers.events;
 
 import com.natamus.randombonemealflowers.util.Util;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.TickTask;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.event.entity.player.BonemealEvent;
+import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 
@@ -30,7 +32,7 @@ import java.util.List;
 
 @EventBusSubscriber
 public class FlowerEvent {
-	@SubscribeEvent
+	@SubscribeEvent(priority = EventPriority.LOW)
 	public void onBonemeal(BonemealEvent e) {
 		Level world = e.getLevel();
 		if (world.isClientSide) {
@@ -50,7 +52,7 @@ public class FlowerEvent {
 			oldblocks.add(block);
 		}
 
-	   world.getServer().execute(() -> {
+	   world.getServer().tell(new TickTask(world.getServer().getTickCount(), () -> {
 		   Iterator < BlockPos > newit = BlockPos.betweenClosedStream(x - 6, y, z - 6, x + 6, y + 1, z + 6).iterator();
 		   while (newit.hasNext()) {
 			   BlockPos bp = newit.next();
@@ -63,6 +65,6 @@ public class FlowerEvent {
 
 			   oldblocks.remove(0);
 		   }
-	   });
+	   }));
 	}
 }

--- a/sources/Random Bone Meal Flowers/src/main/java/com/natamus/randombonemealflowers/events/FlowerEvent.java
+++ b/sources/Random Bone Meal Flowers/src/main/java/com/natamus/randombonemealflowers/events/FlowerEvent.java
@@ -22,7 +22,6 @@ import net.minecraft.server.TickTask;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraftforge.event.entity.player.BonemealEvent;
-import net.minecraftforge.eventbus.api.EventPriority;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
 
@@ -32,7 +31,7 @@ import java.util.List;
 
 @EventBusSubscriber
 public class FlowerEvent {
-	@SubscribeEvent(priority = EventPriority.LOW)
+	@SubscribeEvent
 	public void onBonemeal(BonemealEvent e) {
 		Level world = e.getLevel();
 		if (world.isClientSide) {


### PR DESCRIPTION
Since dispensers did not schedule the task in FlowerEvent and instead ran it immediately, it meant that they didn't have flowers to replace.



Will add more info in this issue : #1398